### PR TITLE
same issue as go-fir, don't use distroless/cc

### DIFF
--- a/.cloudbuild/Dockerfile
+++ b/.cloudbuild/Dockerfile
@@ -3,8 +3,9 @@ WORKDIR /go/src/app
 COPY ./ .
 RUN go build -v -o /app .
 
-# Now copy it into our base image.
-FROM gcr.io/distroless/cc
+# Note: I moved off the official "distroless" image, due to this issue: https://github.com/GoogleContainerTools/distroless/issues/1342
+#       I have no clue of the differences, but this works *shrug*
+FROM cgr.dev/chainguard/glibc-dynamic
 
 COPY --from=build /app/ /app
 COPY --from=build /go/src/app/.private /private

--- a/.cloudbuild/docker-compose.yaml
+++ b/.cloudbuild/docker-compose.yaml
@@ -7,6 +7,11 @@ services:
       - ci.env
     command: go test ./...
 
+  api:
+    image: site-api:local
+    env_file:
+      - ci.env
+
 networks:
   api-ci-network:
     driver: bridge

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,13 +5,13 @@
 
 # For local testing of the slimmed, deployed image
 docker build \
-  -t api:local \
+  -t site-api:local \
   --file .cloudbuild/Dockerfile \
   .
 
 # For local testing of the CI process
 docker build \
-  -t api:local-ci \
+  -t site-api:local-ci \
   --file .cloudbuild/Dockerfile-Ci \
   .
 


### PR DESCRIPTION
Replace distroless image with one that supports a relevant glibc *shrug* `cgr.dev/chainguard/glibc-dynamic`