### PR TITLE
refactor - crawler interface

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -107,13 +107,13 @@ func NewGraph(directed bool) (g *Graph, err error) {
 	return g, nil
 }
 
-// GraphFromFile reads a graph from a file
+// FromFile reads a graph from a file
 // Note the book example reads from user-supplied stdin. I'm following the same formatting, but instead reading from a file
 //
 // The format of the file is:
 // The 1st line has two integers, n and m, which are the number of vertices and edges, respectively.
 // The next m lines contain the edges; each two integers, x and y, the vertices of the edge
-func GraphFromFile(filename string, directed bool) (g *Graph, err error) {
+func FromFile(filename string, directed bool) (g *Graph, err error) {
 	g, err = NewGraph(directed)
 	if err != nil {
 		return nil, err

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -23,9 +23,9 @@ func TestNewGraph(t *testing.T) {
 }
 
 // TestReadFromFile tests the construction of a graph, using the "skeina_graph" format.
-// Note that this is also indirectly testing InsertEdge, which is called by GraphFromFile
+// Note that this is also indirectly testing InsertEdge, which is called by FromFile
 func TestReadFromFile(t *testing.T) {
-	g, err := GraphFromFile("./test_example_1.skeina_graph", true)
+	g, err := FromFile("./test_example_1.skeina_graph", true)
 	if err != nil {
 		t.Error("error when success expected")
 	}
@@ -45,7 +45,7 @@ func TestReadFromFile(t *testing.T) {
 
 // TestBfs tests the breadth-first algorithm
 func TestBfs(t *testing.T) {
-	g, _ := GraphFromFile("./fig_5_9.skeina_graph", false)
+	g, _ := FromFile("./fig_5_9.skeina_graph", false)
 	crawlResult := new(CrawlerCounter)
 
 	g.Bfs(1, crawlResult)
@@ -54,8 +54,8 @@ func TestBfs(t *testing.T) {
 	if crawlResult.NVerticesProcessedEarly != 6 {
 		t.Errorf("Expected nVertices to be 6, got %d", crawlResult.NVerticesProcessedEarly)
 	}
-	if crawlResult.NEdgesProcessed != 7 {
-		t.Errorf("Expected nEdges to be 7, got %d", crawlResult.NEdgesProcessed)
+	if crawlResult.NEdgesProcessed != 6 {
+		t.Errorf("Expected nEdges to be 6, got %d", crawlResult.NEdgesProcessed)
 	}
 }
 
@@ -130,7 +130,7 @@ func TestStack(t *testing.T) {
 }
 
 func TestDfs(t *testing.T) {
-	g, _ := GraphFromFile("./fig_5_9.skeina_graph", false)
+	g, _ := FromFile("./fig_5_9.skeina_graph", false)
 	crawlResult := new(CrawlerCounter)
 	s, _ := g.Dfs(1, crawlResult)
 

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -45,15 +45,17 @@ func TestReadFromFile(t *testing.T) {
 
 // TestBfs tests the breadth-first algorithm
 func TestBfs(t *testing.T) {
-	g, _ := GraphFromFile("./fig_5_9.skeina_graph", true)
-	nVertices, nEdges := g.Bfs(1)
+	g, _ := GraphFromFile("./fig_5_9.skeina_graph", false)
+	crawlResult := new(CrawlerCounter)
+
+	g.Bfs(1, crawlResult)
 
 	// TODO: I think it's working, but unsure of better assertion criteria
-	if nVertices != 6 {
-		t.Errorf("Expected nVertices to be 6, got %d", nVertices)
+	if crawlResult.NVerticesProcessedEarly != 6 {
+		t.Errorf("Expected nVertices to be 6, got %d", crawlResult.NVerticesProcessedEarly)
 	}
-	if nEdges != 7 {
-		t.Errorf("Expected nEdges to be 7, got %d", nEdges)
+	if crawlResult.NEdgesProcessed != 7 {
+		t.Errorf("Expected nEdges to be 7, got %d", crawlResult.NEdgesProcessed)
 	}
 }
 
@@ -129,7 +131,8 @@ func TestStack(t *testing.T) {
 
 func TestDfs(t *testing.T) {
 	g, _ := GraphFromFile("./fig_5_9.skeina_graph", false)
-	s, _ := g.Dfs(1)
+	crawlResult := new(CrawlerCounter)
+	s, _ := g.Dfs(1, crawlResult)
 
 	// TODO: Better test criteria??
 	for i := 1; i <= 6; i++ {


### PR DESCRIPTION
Introduce `Crawler` interface, which pulls out the `process<foo>` functions into an interface. For now I only have a very simpler counter crawler, but I hope to use this pattern for more interesting queries