### PR TITLE
db tutorial - part II

### DIFF
--- a/db/cli.go
+++ b/db/cli.go
@@ -6,6 +6,43 @@ import (
 	"os"
 )
 
+func validateMetaCommand(cmd string) error {
+	switch cmd {
+	case ".exit":
+		return nil
+	}
+
+	return fmt.Errorf("unrecognized meta command: %s", cmd)
+}
+
+func doMetaCommand(cmd string) {
+	switch cmd {
+	case ".exit":
+		fmt.Println("adios!")
+		os.Exit(0)
+	}
+}
+
+func validateStatement(cmd string) error {
+	switch cmd {
+	case "select":
+		return nil
+	case "insert":
+		return nil
+	}
+
+	return fmt.Errorf("unrecognized meta command: %s", cmd)
+}
+
+func doStatement(cmd string) {
+	switch cmd {
+	case "select":
+		fmt.Println("TODO: select handling goes here!")
+	case "insert":
+		fmt.Println("TODO: insert handling goes here!")
+	}
+}
+
 func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 
@@ -14,11 +51,21 @@ func main() {
 		scanner.Scan()
 		input := scanner.Text()
 
-		if input == ".exit" {
-			fmt.Println("adios!")
-			break
-		} else {
-			fmt.Println("TODO: Parse the following command: ", input)
+		if input[0] == '.' {
+			err := validateMetaCommand(input)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			doMetaCommand(input)
+			continue
 		}
+
+		err := validateStatement(input)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		doStatement(input)
 	}
 }

--- a/db/cli.go
+++ b/db/cli.go
@@ -31,7 +31,7 @@ func validateStatement(cmd string) error {
 		return nil
 	}
 
-	return fmt.Errorf("unrecognized meta command: %s", cmd)
+	return fmt.Errorf("unrecognized statement: %s", cmd)
 }
 
 func doStatement(cmd string) {


### PR DESCRIPTION
* Ports part II of this post: https://cstack.github.io/db_tutorial/parts/part2.html
* I've deviated from the C-style enum error pattern in favor of Go's return `error` type and convention Go error checking
* I'm not convinced separating validation from action is necessary, but there may be a reason why the blog does so, so I'm following suit for the time being.